### PR TITLE
SCRUM-16-21: Implemented Opportunity posting and students interested

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -5,41 +5,74 @@ service cloud.firestore {
 
     // Rules for users collection
     match /users/{userId} {
-      // Allow users read/write access ONLY to their own document
       allow read, update, delete: if request.auth != null && request.auth.uid == userId;
-      // Allow any authenticated user to create a user document (needed for signup)
       allow create: if request.auth != null;
-       // Allow any authenticated user to GET (read single doc) any user's profile
-      // (You might want this for profile view pages later, adjust if needed)
+      // Allow reading single user doc (e.g., for profiles) if logged in
       allow get: if request.auth != null;
     }
-
-    // Allow any authenticated user to LIST the users collection for the directory
-    match /users/{document=**} { // This rule targets the collection itself for list operations
+    // Allow listing users (e.g., for directory) if logged in
+    match /users/{document=**} {
       allow list: if request.auth != null;
     }
 
-    // Rules for courses collection (Keep your existing - allows any logged-in user read/write)
+    // Rules for courses collection (Consider making these more specific later)
     match /courses/{courseId} {
-      allow read, write: if request.auth != null;
+      // Example: Allow authenticated users to read, but only owner (professor) to write
+      // allow read: if request.auth != null;
+      // allow write: if request.auth != null && request.auth.uid == resource.data.professorId; // Assuming professorId field exists
+      // For now, keeping your original broader rule:
+       allow read, write: if request.auth != null;
     }
 
-    // Rules for research collection (Keep your existing - allows professor owner specific access)
+    // Rules for research collection
     match /research/{docId} {
-      // Original read rule was more specific - let's keep it unless you need broader read
-      // allow read: if request.auth != null && request.auth.uid == resource.data.professorId;
-      // Allowing any authenticated user to read research might be okay? Revert if needed.
-      allow read: if request.auth != null;
+      // Allow owner to read, create, update, delete
+      allow read: if request.auth != null && resource.data.professorId == request.auth.uid;
       allow create: if request.auth != null && request.resource.data.professorId == request.auth.uid;
-      allow update: if request.auth != null && request.resource.data.professorId == request.auth.uid; // Assuming request.resource for update too
+      allow update: if request.auth != null && resource.data.professorId == request.auth.uid;
       allow delete: if request.auth != null && request.auth.uid == resource.data.professorId;
     }
 
-    // The explicit default deny is no longer strictly needed as rules default to deny,
-    // but you can leave it if you prefer clarity. Ensure it doesn't override specific allows.
-    // It's generally better practice to remove it if you have covered all collections explicitly.
-    // match /{document=**} {
-    //   allow read, write: if false;
-    // }
+    // Rules for the 'opportunities' collection
+    match /opportunities/{opportunityId} {
+      // Allow any logged-in user to read opportunities
+      allow read: if request.auth != null;
+      // Allow creation only by users with role 'professor'
+      allow create: if request.auth != null && get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'professor';
+      // Allow updates/deletes only by the professor who created it
+      allow update, delete: if request.auth != null && request.auth.uid == resource.data.professorId;
+    }
+
+    // --- Rules for 'interests' collection (Restored Secure List Rule) ---
+    match /interests/{interestId} {
+      // Students can create their own interest records if they have 'student' role
+      allow create: if request.auth != null &&
+                       request.resource.data.studentId == request.auth.uid &&
+                       get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'student';
+
+      // Students can read (get) or delete ONLY their own interest records
+      allow get, delete: if request.auth != null && request.auth.uid == resource.data.studentId;
+
+      // Allow professors to GET any single interest document IF they own the opportunity
+      // (This rule might overlap with student 'get', Firestore allows if *any* rule passes)
+      allow get: if request.auth != null &&
+                    get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'professor' &&
+                    resource.data.professorId == request.auth.uid;
+
+      // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+      // UPDATED LIST RULE: Allow professors OR students querying their own interests
+      allow list: if
+          // Condition 1: Allow professors (based on role check)
+          (request.auth != null && get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'professor') ||
+          // Condition 2: Allow students IF the FIRST query filter is studentId == their own UID
+          (request.auth != null &&
+            get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'student' 
+          );
+      // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+      // Prevent updating interest records directly
+      allow update: if false;
+    }
+    // --- End Rules for 'interests' ---
   }
 }

--- a/frontend/src/components/opportunities/AddOpportunityForm.jsx
+++ b/frontend/src/components/opportunities/AddOpportunityForm.jsx
@@ -1,0 +1,186 @@
+/* eslint-disable react/prop-types */
+// frontend/src/components/opportunities/AddOpportunityForm.jsx
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField,
+  FormControl, InputLabel, Select, MenuItem, FormControlLabel, Checkbox, FormHelperText, CircularProgress
+} from '@mui/material';
+import { Timestamp } from 'firebase/firestore'; // Import Timestamp
+
+const AddOpportunityForm = ({ open, onClose, onSave, initialData = null, isSaving }) => {
+  // Initialize form state: Use initialData if editing, otherwise default empty values
+  const getInitialState = useCallback(() => ({
+    title: initialData?.title || '',
+    description: initialData?.description || '',
+    type: initialData?.type || 'TA', // Default type
+    allowInterest: initialData?.allowInterest !== undefined ? initialData.allowInterest : true, // Default to allowing interest
+    deadline: initialData?.deadline ? initialData.deadline.toDate().toISOString().split('T')[0] : '', // Format for date input
+    // Add other fields from your data model as needed
+  }), [initialData]);
+
+  const [formData, setFormData] = useState(getInitialState());
+  const [formErrors, setFormErrors] = useState({});
+
+  // Reset form when initialData changes (when opening for edit) or when dialog closes/opens
+  useEffect(() => {
+    if (open) {
+        setFormData(getInitialState());
+        setFormErrors({}); // Clear errors when dialog opens
+    }
+  }, [getInitialState, initialData, open]);
+
+  const handleChange = (event) => {
+    const { name, value, type, checked } = event.target;
+    setFormData(prev => ({
+      ...prev,
+      [name]: type === 'checkbox' ? checked : value
+    }));
+    // Clear specific error when user starts typing
+    if (formErrors[name]) {
+        setFormErrors(prev => ({...prev, [name]: null}));
+    }
+  };
+
+  const validateForm = () => {
+    let errors = {};
+    if (!formData.title.trim()) errors.title = "Title is required.";
+    if (!formData.description.trim()) errors.description = "Description is required.";
+    if (!formData.type) errors.type = "Opportunity type is required.";
+    // Basic date validation (doesn't prevent past dates, add more if needed)
+    if (formData.deadline && isNaN(Date.parse(formData.deadline))) {
+        errors.deadline = "Invalid date format.";
+    }
+    // Add more validation as needed (e.g., date format)
+    setFormErrors(errors);
+    return Object.keys(errors).length === 0; // Return true if no errors
+  };
+
+  const handleSave = () => {
+    if (!validateForm()) return;
+
+    // Convert deadline string back to Timestamp if needed
+    let deadlineTimestamp = null;
+    if (formData.deadline) {
+        try {
+            // Attempt to create a date object at the beginning of the selected day in local time
+            const dateParts = formData.deadline.split('-');
+            const utcDate = new Date(Date.UTC(parseInt(dateParts[0]), parseInt(dateParts[1]) - 1, parseInt(dateParts[2])));
+            if (isNaN(utcDate.getTime())) { // Check if date is valid
+                throw new Error("Invalid date components");
+             }
+            deadlineTimestamp = Timestamp.fromDate(utcDate);
+        } catch (dateError) {
+            console.error("Error parsing date:", dateError);
+            setFormErrors(prev => ({...prev, deadline: "Invalid date format."}));
+            return; // Stop save if date is invalid
+        }
+    }
+
+
+    // Prepare data to save (exclude deadline if empty)
+    const dataToSave = {
+        ...formData,
+        ...(deadlineTimestamp && { deadline: deadlineTimestamp }) // Only include deadline if it's valid
+    };
+     if (!formData.deadline) {
+        delete dataToSave.deadline; // Ensure deadline field is not sent if empty
+    }
+
+
+    onSave(dataToSave); // Pass the processed data to the parent save handler
+  };
+
+  return (
+    <Dialog open={open} onClose={() => !isSaving && onClose()} maxWidth="sm" fullWidth> {/* Prevent closing while saving */}
+      <DialogTitle>{initialData ? 'Edit Opportunity Post' : 'Create New Opportunity Post'}</DialogTitle>
+      <DialogContent>
+        <TextField
+          autoFocus
+          margin="dense"
+          name="title"
+          label="Opportunity Title"
+          type="text"
+          fullWidth
+          variant="outlined"
+          value={formData.title}
+          onChange={handleChange}
+          required
+          error={!!formErrors.title}
+          helperText={formErrors.title}
+          disabled={isSaving}
+        />
+        <TextField
+          margin="dense"
+          name="description"
+          label="Description"
+          type="text"
+          fullWidth
+          variant="outlined"
+          multiline
+          rows={4}
+          value={formData.description}
+          onChange={handleChange}
+          required
+          error={!!formErrors.description}
+          helperText={formErrors.description}
+          disabled={isSaving}
+        />
+        <FormControl fullWidth margin="dense" required error={!!formErrors.type} disabled={isSaving}>
+          <InputLabel id="opportunity-type-label">Type</InputLabel>
+          <Select
+            labelId="opportunity-type-label"
+            name="type"
+            value={formData.type}
+            label="Type"
+            onChange={handleChange}
+          >
+            <MenuItem value="TA">TA</MenuItem>
+            <MenuItem value="Research Assistant">Research Assistant</MenuItem>
+            <MenuItem value="Grader">Grader</MenuItem>
+            <MenuItem value="Lab Assistant">Lab Assistant</MenuItem>
+            <MenuItem value="Job">Job</MenuItem>
+            <MenuItem value="Volunteer">Volunteer</MenuItem>
+            <MenuItem value="Other">Other</MenuItem>
+          </Select>
+           {formErrors.type && <FormHelperText>{formErrors.type}</FormHelperText>}
+        </FormControl>
+         <TextField
+          margin="dense"
+          name="deadline"
+          label="Application Deadline (Optional)"
+          type="date" // Use date input type
+          fullWidth
+          variant="outlined"
+          value={formData.deadline}
+          onChange={handleChange}
+          InputLabelProps={{ shrink: true }} // Keep label floated
+          error={!!formErrors.deadline}
+          helperText={formErrors.deadline}
+          disabled={isSaving}
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              name="allowInterest"
+              checked={formData.allowInterest}
+              onChange={handleChange}
+              color="primary"
+              disabled={isSaving}
+            />
+          }
+          label="Allow students to mark themselves as 'Interested'"
+          sx={{ mt: 1 }}
+        />
+
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isSaving}>Cancel</Button>
+        <Button onClick={handleSave} variant="contained" disabled={isSaving}>
+          {isSaving ? <CircularProgress size={24} /> : (initialData ? 'Update Post' : 'Create Post')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default AddOpportunityForm;

--- a/frontend/src/components/opportunities/InterestedStudentsDialog.jsx
+++ b/frontend/src/components/opportunities/InterestedStudentsDialog.jsx
@@ -1,0 +1,173 @@
+/* eslint-disable react/prop-types */
+// frontend/src/components/opportunities/InterestedStudentsDialog.jsx
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions, Button, List, ListItem, ListItemText,
+  ListItemAvatar, Avatar, Typography, CircularProgress, Box, Link as MuiLink, Divider, IconButton
+} from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom'; // For linking to profiles
+import { collection, query, where, getDocs, orderBy } from 'firebase/firestore';
+import { db } from '../../firebase'; // Adjust path if needed
+import CloseIcon from '@mui/icons-material/Close';
+import DescriptionIcon from '@mui/icons-material/Description'; // Icon for resume
+import AccountCircleIcon from '@mui/icons-material/AccountCircle'; // Icon for profile link
+
+// Helper function to get initials (can be moved to utils)
+const getInitials = (name) => {
+    if (!name) return '?';
+    const parts = name.split(' ');
+    return parts.map((p) => p[0]?.toUpperCase() || '').join('') || '?';
+};
+
+const InterestedStudentsDialog = ({ open, onClose, opportunityId, opportunityTitle, professorId }) => {
+  const [interestedStudents, setInterestedStudents] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    // Fetch data only when the dialog is open and an opportunityId is provided
+    if (open && opportunityId && professorId) {
+      const fetchInterestedStudents = async () => {
+        setLoading(true);
+        setError(null);
+        setInterestedStudents([]); // Clear previous results
+        console.log(`Workspaceing interested students for opportunity: ${opportunityId} by professor: ${professorId}`);
+
+        try {
+          const interestsCollectionRef = collection(db, 'interests');
+          // --- MODIFIED QUERY ---
+          const q = query(
+                interestsCollectionRef,
+                where('professorId', '==', professorId), // <-- ADDED filter by professorId
+                where('opportunityId', '==', opportunityId),
+                orderBy('timestamp', 'desc')
+            );
+            // --- END MODIFIED QUERY ---
+
+          const querySnapshot = await getDocs(q);
+          const studentsList = querySnapshot.docs.map(doc => ({
+            id: doc.id, // The ID of the interest document itself
+            ...doc.data() // Includes studentId, studentName, studentEmail, studentResumeLink, timestamp
+          }));
+
+          console.log("Fetched interested students:", studentsList);
+          setInterestedStudents(studentsList);
+
+        } catch (err) {
+            console.error("Error fetching interested students:", err);
+            // Check if the error is permissions or maybe missing index now
+            if (err.code === 'permission-denied') {
+                setError("You don't have permission to view this data.");
+            } else if (err.code === 'failed-precondition') {
+                 setError("Query requires a Firestore index. Check console for link.");
+                 console.error("INDEX REQUIRED: Check the Firebase console error link for this query:", err);
+            } else {
+                setError("Failed to load interested students.");
+            }
+        } finally {
+          setLoading(false);
+        }
+      };
+
+      fetchInterestedStudents();
+    }
+  }, [open, opportunityId, professorId]); // Re-fetch if dialog opens or opportunityId changes
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth scroll="paper">
+      <DialogTitle sx={{ m: 0, p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          Interested Students for: {opportunityTitle || 'Opportunity'}
+           <IconButton aria-label="close" onClick={onClose} sx={{ color: (theme) => theme.palette.grey[500] }}>
+                <CloseIcon />
+            </IconButton>
+      </DialogTitle>
+      <DialogContent dividers={true}> {/* Add dividers */}
+        {loading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}><CircularProgress /></Box>
+        ) : error ? (
+          <Typography color="error" sx={{ p: 2 }}>{error}</Typography>
+        ) : interestedStudents.length > 0 ? (
+          <List disablePadding>
+            {interestedStudents.map((interest, index) => (
+              <React.Fragment key={interest.id}>
+                <ListItem alignItems="flex-start" sx={{ py: 1.5 }}> {/* Added padding */}
+                  <ListItemAvatar>
+                    {/* --- Use studentPhotoLink for Avatar source --- */}
+                    <Avatar
+                       src={interest.studentPhotoLink || undefined} // Use photo link if available
+                       alt={interest.studentName}
+                    >
+                       {/* Fallback to initials if no photo link */}
+                       {!interest.studentPhotoLink && getInitials(interest.studentName)}
+                    </Avatar>
+                    {/* --- End Avatar Update --- */}
+                  </ListItemAvatar>
+                  <ListItemText
+                    primary={
+                         <Typography variant="body1" component="span" sx={{ fontWeight: 'medium' }}>
+                             {interest.studentName || 'Unknown Student'}
+                         </Typography>
+                    }
+                    secondary={
+                      <>
+                        {/* Email */}
+                        <Typography component="div" variant="body2" color="text.primary" sx={{ mb: 0.5 }}> {/* Use div for block */}
+                            {interest.studentEmail || 'No Email'}
+                        </Typography>
+
+                        {/* Links Box */}
+                        <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', flexWrap: 'wrap', mb: 0.5 }}>
+                            {/* Resume Link */}
+                            {interest.studentResumeLink ? (
+                            <MuiLink
+                                href={interest.studentResumeLink}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                variant="body2"
+                                sx={{ display: 'inline-flex', alignItems: 'center' }}
+                            >
+                                <DescriptionIcon sx={{ fontSize: '1rem', mr: 0.5 }} /> Resume/CV
+                            </MuiLink>
+                            ) : (
+                                <Typography component="span" variant="caption" color="text.secondary"> (No Resume) </Typography>
+                            )}
+
+                            {/* Profile Link Button */}
+                            <Button
+                                component={RouterLink} // Use React Router Link
+                                to={`/profile/${interest.studentId}`} // Dynamic link to student's profile
+                                size="small"
+                                variant="text" // Use text variant for less emphasis
+                                startIcon={<AccountCircleIcon />}
+                                sx={{ p: '2px 4px', textTransform: 'none' }} // Adjust padding
+                            >
+                                View Profile
+                            </Button>
+                        </Box>
+
+                        {/* Timestamp */}
+                        <Typography component="span" variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                            Interested On: {interest.timestamp?.toDate().toLocaleDateString()}
+                        </Typography>
+                      </>
+                    }
+                  />
+                </ListItem>
+                {index < interestedStudents.length - 1 && <Divider variant="inset" component="li" />}
+              </React.Fragment>
+            ))}
+          </List>
+        ) : (
+          <Typography sx={{ p: 3, textAlign: 'center' }} color="text.secondary">
+              No students have expressed interest in this opportunity yet.
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default InterestedStudentsDialog;

--- a/frontend/src/components/opportunities/OpportunityFeed.jsx
+++ b/frontend/src/components/opportunities/OpportunityFeed.jsx
@@ -1,0 +1,304 @@
+/* eslint-disable no-unused-vars */
+// src/components/opportunities/OpportunityFeed.jsx
+import React, { useState, useEffect } from 'react';
+import { Box, Typography, CircularProgress, Alert, ToggleButtonGroup, ToggleButton } from '@mui/material';
+// Import necessary Firestore functions and auth
+import { collection, query, where, orderBy, getDocs, addDoc, doc, getDoc, Timestamp, deleteDoc, limit } from 'firebase/firestore';
+import { db, auth } from '../../firebase'; // Adjust path if needed
+import OpportunityListItem from './OpportunityListItem'; // Adjust path if needed
+import ViewListIcon from '@mui/icons-material/ViewList'; // Icon for All
+import StarIcon from '@mui/icons-material/Star'; // Icon for Interested
+
+const OpportunityFeed = () => {
+  const [opportunities, setOpportunities] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [feedError, setFeedError] = useState(null); // Renamed error state for clarity
+  // State to track which opportunity's interest button is being processed
+  const [processingInterestId, setProcessingInterestId] = useState(null);
+  // --- New State: Store IDs of opportunities the student is interested in ---
+  const [interestedOpportunityIds, setInterestedOpportunityIds] = useState(new Set());
+
+  // --- State to manage the current view ('all' or 'interested') ---
+  const [currentView, setCurrentView] = useState('all');
+
+  // --- New state to track removal processing ---
+  const [processingRemovalId, setProcessingRemovalId] = useState(null);
+
+
+  // --- Modified useEffect to fetch both opportunities and interests ---
+  useEffect(() => {
+    let isMounted = true; // Prevent state updates if component unmounts
+
+    const fetchInitialData = async () => {
+      if (!isMounted) return; // Exit if unmounted
+
+      setLoading(true);
+      setFeedError(null);
+      setInterestedOpportunityIds(new Set()); // Reset interests on fetch
+
+      try {
+        const currentUser = auth.currentUser;
+        let interestsPromise = Promise.resolve([]); // Default to empty if not logged in
+
+        // Prepare fetch for interests ONLY if user is logged in
+        if (currentUser) {
+          const interestsCollectionRef = collection(db, 'interests');
+          // Query specifically for the current student's interests
+          const interestsQuery = query(interestsCollectionRef, where('studentId', '==', currentUser.uid));
+           // Rule check: This query has studentId as first filter, should be allowed by updated rule
+          interestsPromise = getDocs(interestsQuery);
+        }
+
+        // Prepare fetch for all opportunities
+        const opportunitiesCollectionRef = collection(db, 'opportunities');
+        const opportunitiesQuery = query(opportunitiesCollectionRef, orderBy('createdAt', 'desc'));
+        const opportunitiesPromise = getDocs(opportunitiesQuery);
+
+        // Fetch both concurrently
+        const [opportunitiesSnapshot, interestsSnapshot] = await Promise.all([
+            opportunitiesPromise,
+            interestsPromise
+        ]);
+
+        // Process opportunities if component is still mounted
+        if (isMounted) {
+            const fetchedOpportunities = opportunitiesSnapshot.docs.map(doc => ({
+                id: doc.id,
+                ...doc.data(),
+            }));
+            setOpportunities(fetchedOpportunities);
+
+            // Process interests if component is still mounted
+            if (currentUser && interestsSnapshot) {
+                 const fetchedInterestedIds = new Set(
+                    interestsSnapshot.docs.map(doc => doc.data().opportunityId)
+                 );
+                 setInterestedOpportunityIds(fetchedInterestedIds);
+            }
+        }
+
+      } catch (err) {
+        console.error("Error fetching initial data:", err);
+        if (isMounted) {
+          setFeedError("Failed to load data. Please try again later.");
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchInitialData();
+
+    // Cleanup function to set isMounted to false when component unmounts
+    return () => {
+      isMounted = false;
+    };
+  }, []); // Run only on mount
+
+
+  // --- Handler Function for Marking Interest ---
+  const handleMarkInterest = async (opportunityId, professorId) => {
+    // 1. Check if user is logged in
+    if (!auth.currentUser) {
+      alert("Please log in to mark your interest."); // Or use a more sophisticated notification
+      return;
+    }
+    // Prevent multiple simultaneous requests for different items
+    if (processingInterestId) return;
+
+    const studentId = auth.currentUser.uid;
+    setProcessingInterestId(opportunityId); // Set loading state for this specific item
+    setFeedError(null); // Clear previous errors specific to the feed loading
+
+    try {
+      // 1. Fetch student profile data (name, resume link, AND photo link)
+      const studentDocRef = doc(db, 'users', studentId);
+      const studentDocSnap = await getDoc(studentDocRef);
+      if (!studentDocSnap.exists()) {
+        throw new Error("Could not find your student profile data.");
+      }
+      const studentData = studentDocSnap.data();
+      const studentName = studentData.name || 'Unknown Student';
+      const studentEmail = auth.currentUser.email;
+      const studentResumeLink = studentData.resumeLink || '';
+      // --- Get the photo link ---
+      const studentPhotoLink = studentData.photoLink || ''; // Get photoLink, default to empty string
+
+      // 2. Prepare interest data (including photo link)
+      const interestData = {
+        opportunityId: opportunityId,
+        studentId: studentId,
+        professorId: professorId,
+        studentName: studentName,
+        studentEmail: studentEmail,
+        studentResumeLink: studentResumeLink,
+        studentPhotoLink: studentPhotoLink, // <-- Add photo link here
+        timestamp: Timestamp.now()
+      };
+
+      // 3. Add the interest document
+      const interestsCollectionRef = collection(db, 'interests');
+      await addDoc(interestsCollectionRef, interestData);
+
+      // 4. Update Local State Immediately
+      setInterestedOpportunityIds(prevSet => new Set(prevSet).add(opportunityId));
+
+      console.log("Interest marked successfully for:", opportunityId);
+      alert("Interest marked successfully!");
+
+    } catch (err) {
+        // Check if the error is specifically permission denied on CREATE
+        if (err.code === 'permission-denied') {
+             alert("Permission denied. Ensure you are logged in as a student.");
+        } else {
+             alert(`Failed to mark interest: ${err.message}`);
+        }
+        console.error("Error marking interest:", err);
+        alert(`Failed to mark interest: ${err.message}`)
+    } finally {
+      // Reset the loading state for this item regardless of success/failure
+      setProcessingInterestId(null);
+    }
+  };
+  // --- End Handler ---
+
+
+  // --- Handler Function for Removing Interest ---
+  const handleRemoveInterest = async (opportunityId) => {
+    if (!auth.currentUser) {
+      alert("Please log in.");
+      return;
+    }
+    // Prevent clicking if another add/remove is processing
+    if (processingInterestId || processingRemovalId) return;
+
+    const studentId = auth.currentUser.uid;
+    setProcessingRemovalId(opportunityId); // Set processing state for removal
+    setFeedError(null);
+
+    try {
+      // 1. Find the specific interest document ID to delete
+      const interestsCollectionRef = collection(db, 'interests');
+      const interestQuery = query(
+        interestsCollectionRef,
+        where('opportunityId', '==', opportunityId),
+        where('studentId', '==', studentId),
+        limit(1) // We only expect one match
+      );
+      const interestSnap = await getDocs(interestQuery);
+
+      if (interestSnap.empty) {
+        // If the button was shown, the record should exist, but handle defensively
+        console.warn("Tried to remove interest, but couldn't find the record for opportunity:", opportunityId);
+        throw new Error("Could not find the interest record to remove.");
+      }
+
+      // 2. Get the document ID and delete the document
+      const interestDocId = interestSnap.docs[0].id;
+      const interestDocRef = doc(db, 'interests', interestDocId);
+      // Security Rule Check: The existing 'delete' rule for interests should allow this
+      await deleteDoc(interestDocRef);
+
+      // 3. Update local state immediately to reflect removal
+      setInterestedOpportunityIds(prevSet => {
+        const newSet = new Set(prevSet);
+        newSet.delete(opportunityId); // Remove the ID from the local set
+        return newSet;
+      });
+
+      console.log("Interest removed successfully for:", opportunityId);
+      alert("Interest removed successfully!");
+
+    } catch (err) {
+      console.error("Error removing interest:", err);
+      alert(`Failed to remove interest: ${err.message}`);
+    } finally {
+      setProcessingRemovalId(null); // Reset processing state for removal
+    }
+  };
+  // --- End Handler ---
+
+
+  // --- Handler for changing the view ---
+  const handleViewChange = (event, newView) => {
+    // Ensure a view is always selected
+    if (newView !== null) {
+      setCurrentView(newView);
+    }
+  };
+
+  // --- Filter opportunities based on the current view ---
+  const opportunitiesToDisplay = currentView === 'all'
+    ? opportunities // Show all if 'all' view is selected
+    : opportunities.filter(opp => interestedOpportunityIds.has(opp.id)); // Show only interested ones otherwise
+
+    return (
+        <Box>
+          {/* View Toggle Buttons */}
+          <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
+            <ToggleButtonGroup
+              value={currentView}
+              exclusive // Ensures only one button can be active
+              onChange={handleViewChange}
+              aria-label="Opportunity view selection"
+            >
+              <ToggleButton value="all" aria-label="all opportunities">
+                 <ViewListIcon sx={{ mr: 1 }} /> All Opportunities
+              </ToggleButton>
+              <ToggleButton value="interested" aria-label="interested opportunities">
+                 <StarIcon sx={{ mr: 1 }} /> My Interests
+              </ToggleButton>
+            </ToggleButtonGroup>
+          </Box>
+
+          {/* Conditional Title based on view */}
+          <Typography variant="h6" gutterBottom>
+            {currentView === 'all' ? 'Available Opportunities' : 'Opportunities You\'re Interested In'}
+          </Typography>
+
+          {/* Loading Indicator */}
+          {loading && ( <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}> <CircularProgress /> </Box> )}
+
+          {/* Error Message */}
+          {feedError && ( <Alert severity="error" sx={{ mt: 2 }}>{feedError}</Alert> )}
+
+          {/* No Opportunities Message (Context-aware) */}
+          {!loading && !feedError && opportunitiesToDisplay.length === 0 && (
+            <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center', p: 3 }}>
+              {currentView === 'all'
+                 ? "No opportunities have been posted yet. Check back later!"
+                 : "You haven't marked interest in any opportunities yet."
+              }
+            </Typography>
+          )}
+
+          {/* Display Filtered Opportunities List */}
+          {!loading && !feedError && opportunitiesToDisplay.length > 0 && (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 2 }}>
+              {/* Map over the FILTERED array */}
+              {opportunitiesToDisplay.map((opp) => {
+                const isAlreadyInterested = interestedOpportunityIds.has(opp.id);
+                return (
+                  <OpportunityListItem
+                    key={opp.id}
+                    opportunity={opp}
+                    viewMode="student"
+                    onMarkInterest={handleMarkInterest}
+                    isProcessingInterest={processingInterestId === opp.id}
+                    isAlreadyInterested={isAlreadyInterested}
+                    // We will add onRemoveInterest next
+                    // --- Pass down the new handler and state ---
+                    onRemoveInterest={handleRemoveInterest}
+                    isProcessingRemoval={processingRemovalId === opp.id}
+                  />
+                );
+              })}
+            </Box>
+          )}
+        </Box>
+      );
+};
+
+export default OpportunityFeed;

--- a/frontend/src/components/opportunities/OpportunityListItem.jsx
+++ b/frontend/src/components/opportunities/OpportunityListItem.jsx
@@ -1,0 +1,134 @@
+/* eslint-disable react/prop-types */
+// frontend/src/components/opportunities/OpportunityListItem.jsx
+import { Paper, Box, Typography, Chip, IconButton, Button, Divider } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import GroupIcon from '@mui/icons-material/Group';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'; // Import an icon for the student button
+import HighlightOffIcon from '@mui/icons-material/HighlightOff'; // Import an icon for remove interest
+import { Timestamp } from 'firebase/firestore';
+
+// Helper function to format Firestore Timestamps
+const formatDate = (timestamp) => {
+  if (!timestamp || !(timestamp instanceof Timestamp)) {
+    return 'N/A';
+  }
+  return timestamp.toDate().toLocaleDateString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric'
+  });
+};
+
+// Add onMarkInterest prop to the component signature
+const OpportunityListItem = ({
+    opportunity,
+    onEdit,
+    onDelete,
+    onViewInterested,
+    viewMode,
+    onMarkInterest,
+    isProcessingInterest, // <-- Accept the new prop // <-- Handler function for student marking interest
+    isAlreadyInterested, // <-- New prop
+    onRemoveInterest, // <-- New handler prop
+    isProcessingRemoval // <-- New prop to disable remove button during processing
+}) => {
+
+    const isProfessorView = viewMode === 'professor';
+    const isStudentView = viewMode === 'student';
+
+    // Placeholder handler - the real logic will be in the parent component (OpportunityFeed)
+    const handleInterestClick = () => {
+        console.log(`Student interested in opportunity: ${opportunity.id}, professor: ${opportunity.professorId}`);
+        if (onMarkInterest) {
+            // Pass the necessary IDs up to the parent component's handler
+            onMarkInterest(opportunity.id, opportunity.professorId);
+        }
+    };
+
+    // --- Handler for removing interest ---
+    const handleRemoveInterestClick = () => {
+        console.log(`Student removing interest from opportunity: ${opportunity.id}`);
+        if (onRemoveInterest) {
+            // Pass only the opportunityId up, as studentId is known in parent
+            onRemoveInterest(opportunity.id);
+        }
+    };
+
+    return (
+        <Paper elevation={2} sx={{ p: 2, mb: 2, borderRadius: 2 }}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', flexWrap: 'wrap' }}>
+                {/* Left side: Title, Type, Interest Chip */}
+                <Box sx={{ mb: 1 }}>
+                    <Typography variant="h6" gutterBottom>{opportunity.title}</Typography>
+                    <Chip label={opportunity.type || 'General'} size="small" sx={{ mr: 1, mb: 1 }} />
+                    {opportunity.allowInterest && <Chip label="Interest Enabled" size="small" color="success" variant="outlined" sx={{ mb: 1 }} />}
+                </Box>
+
+                {/* Right side: Controls Container */}
+                <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center', flexShrink: 0 }}>
+                    {/* Render Professor Controls ONLY if isProfessorView */}
+                    {isProfessorView && (
+                        <>
+                            {opportunity.allowInterest && onViewInterested && (
+                                <Button size="small" startIcon={<GroupIcon />} onClick={() => onViewInterested(opportunity.id)} variant="outlined" sx={{ textTransform: 'none', whiteSpace: 'nowrap' }}> View Interested </Button>
+                            )}
+                            {onEdit && (
+                                <IconButton size="small" onClick={() => onEdit(opportunity)} aria-label="edit"> <EditIcon fontSize="inherit" /> </IconButton>
+                            )}
+                            {onDelete && (
+                                <IconButton size="small" onClick={() => onDelete(opportunity.id)} aria-label="delete"> <DeleteIcon fontSize="inherit" color="error"/> </IconButton>
+                            )}
+                        </>
+                    )}
+
+                    {/* Student Buttons: Render based on interest status */}
+                    {isStudentView && opportunity.allowInterest && (
+                        <> {/* Use Fragment to group student buttons */}
+                            {!isAlreadyInterested && onMarkInterest && ( // Show "I'm Interested" only if NOT already interested
+                                <Button
+                                    variant="contained"
+                                    size="small"
+                                    startIcon={<CheckCircleOutlineIcon />}
+                                    onClick={handleInterestClick}
+                                    disabled={isProcessingInterest}
+                                    sx={{ whiteSpace: 'nowrap' }}
+                                >
+                                    {isProcessingInterest ? 'Processing...' : "I'm Interested"}
+                                </Button>
+                            )}
+                            {isAlreadyInterested && onRemoveInterest && ( // Show "Remove Interest" only IF already interested
+                                <Button
+                                    variant="outlined" // Different style for remove
+                                    size="small"
+                                    color="error" // Use error color
+                                    startIcon={<HighlightOffIcon />}
+                                    onClick={handleRemoveInterestClick}
+                                    disabled={isProcessingRemoval} // Use separate processing state
+                                    sx={{ whiteSpace: 'nowrap' }}
+                                >
+                                    {isProcessingRemoval ? 'Removing...' : "Remove Interest"}
+                                </Button>
+                            )}
+                         </>
+                    )}
+                </Box>
+            </Box>
+            <Divider sx={{ my: 1 }} />
+            {/* Description and Dates */}
+            <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', mb: 1 }}>
+                {opportunity.description}
+            </Typography>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 1, flexWrap: 'wrap', gap: 1 }}>
+                <Typography variant="caption" color="text.secondary">
+                    Posted: {formatDate(opportunity.createdAt)} by {opportunity.professorName || 'Professor'}
+                </Typography>
+                {opportunity.deadline && (
+                    <Typography variant="caption" color="error">
+                        Deadline: {formatDate(opportunity.deadline)}
+                    </Typography>
+                )}
+            </Box>
+        </Paper>
+    );
+};
+
+export default OpportunityListItem;

--- a/frontend/src/pages/StudentDashboard.jsx
+++ b/frontend/src/pages/StudentDashboard.jsx
@@ -19,6 +19,7 @@ import ProfileHeader from '../components/profile/ProfileHeader'; // Reuse Profil
 import EditableField from '../components/common/EditableField'; // Reuse EditableField
 import EditableTextArea from '../components/common/EditableTextArea'; // Reuse EditableTextArea
 import FileUploadField from '../components/common/FileUploadField'; // Reuse FileUploadField
+import OpportunityFeed from '../components/opportunities/OpportunityFeed'; // Make sure this import exists and path is correct
 
 // Icons (Optional, but needed if reusing ProfileHeader with edit icons etc.)
 import EditIcon from '@mui/icons-material/Edit';
@@ -259,7 +260,7 @@ const StudentDashboard = () => {
           <Tab label="Profile" {...a11yProps(0)} />
           <Tab label="Research & Interests" {...a11yProps(1)} />
           <Tab label="Courses Enrolled" {...a11yProps(2)} />
-          <Tab label="Posts Interested In" {...a11yProps(3)} />
+          <Tab label="Opportunities Interested In" {...a11yProps(3)} />
         </Tabs>
 
         {/* --- Profile Tab (US3.1 & US3.2) --- */}
@@ -347,9 +348,10 @@ const StudentDashboard = () => {
            {/* Future: List of courses */}
         </TabPanel>
         <TabPanel value={tabValue} index={3}>
-            <Typography variant="h6">Posts Interested In</Typography>
+            <Typography variant="h6">Opportunites</Typography>
             <Typography variant="body2" color="textSecondary">(Content for US3.5 will go here)</Typography>
-           {/* Future: List of bookmarked/applied posts */}
+           {/* Future: List of bookmarked/applied opportunties */}
+           <OpportunityFeed />
         </TabPanel>
       </Paper>
 


### PR DESCRIPTION
Added opportunity management and student interest workflow

Implements the core functionality for professors to post opportunities
and for students to view and express interest in them.

- Professors can CRUD opportunities via their dashboard.
- Professors can view interested students (with enhanced details).
- Students can view all opportunities via a feed.
- Students can mark/unmark interest in opportunities.
- Students can toggle view between all/interested opportunities.
- Adds Firestore collections, rules, and indexes for opportunities/interests.